### PR TITLE
fix(meta): remove deprecated ReflectionProperty::setAccessible() in Annotation::jsonSerialize

### DIFF
--- a/src/Meta/Annotation.php
+++ b/src/Meta/Annotation.php
@@ -67,9 +67,7 @@ abstract class Annotation implements \JsonSerializable
 		$array = [];
 		
 		foreach ($reflectionClass->getProperties() as $property) {
-			$property->setAccessible(true);
 			$array[$property->getName()] = $property->getValue($this);
-			$property->setAccessible(false);
 		}
 		
 		return $array;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes `ReflectionProperty::setAccessible()` calls from `Annotation::jsonSerialize()`.

On PHP 8.5, `setAccessible()` is deprecated because it has had no effect since PHP 8.1 — `getValue()` already works on protected/private properties without explicitly unlocking them.

## Context

During `composer migrate` in projects using `liquiddesign/migrator`, `Migrator\Scripts::syncDatabase()` serializes StORM meta objects (`Column`, `Table`, `Index`, …) via `jsonSerialize()`. Each call triggered a deprecation warning on PHP 8.5, often hundreds of times per migrate run.

This was the only use of `setAccessible()` in the storm package.

## Change

In `src/Meta/Annotation.php`, the reflection loop now only calls `getValue()`:

```php
foreach ($reflectionClass->getProperties() as $property) {
    $array[$property->getName()] = $property->getValue($this);
}
```

Serialization output is unchanged on PHP 8.1+.

## Verification

- [ ] `composer test` / `vendor/bin/tester tests/`
- [ ] After merge: `composer update liquiddesign/storm` in monorepo, then `composer migrate` — no `setAccessible()` deprecations in Tracy log

## Related

Fixes PHP 8.5 deprecation noise reported when running schema sync via `liquiddesign/migrator`. No changes required in migrator.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29369f4a-9a22-400b-93f7-95a8e4f51e07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29369f4a-9a22-400b-93f7-95a8e4f51e07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

